### PR TITLE
move ci release to last

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,26 +15,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-amd64.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/tags/*
-    event:
-    - tag
-
 - name: docker-publish-master
   image: plugins/docker
   settings:
@@ -73,6 +53,26 @@ steps:
     - refs/tags/*
     event:
     - tag
+
+- name: github_binary_release
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    prerelease: true
+    checksum:
+      - sha256
+    checksum_file: CHECKSUMsum-amd64.txt
+    checksum_flatten: true
+    files:
+      - "dist/artifacts/*"
+  when:
+    instance:
+      - drone-publish.rancher.io
+    ref:
+      - refs/tags/*
+    event:
+      - tag
 
 volumes:
 - name: docker


### PR DESCRIPTION
**Problem**
CI is stuck in the GitHub release step.
https://drone-publish.rancher.io/harvester/eventrouter/6/1/3

**Workaround**
Move the GitHub release step to the last position.