### PR TITLE
Log app info when it starts

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	name = "harvester-eventrouter"
+)
+
+var (
+	VERSION string
+)
+
 // addr tells us what address to have the Prometheus metrics listen on.
 var addr = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
 
@@ -108,6 +116,8 @@ func main() {
 	var wg sync.WaitGroup
 
 	clientset := loadConfig()
+
+	glog.Infof("Starting %v version %v", name, VERSION)
 
 	var lastResourceVersionPosition string
 	var mostRecentResourceVersion *string

--- a/scripts/build
+++ b/scripts/build
@@ -10,9 +10,7 @@ if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
 
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/eventrouter
-
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/eventrouter-"$arch"
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS $OTHER_LINKFLAGS" -o bin/eventrouter-"$arch"
 done
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Log the info when app starts.
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Log the info when app starts.
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8486

other PRs: https://github.com/harvester/harvester/pull/8487  https://github.com/harvester/network-controller-harvester/pull/174

#### Test plan:
<!-- Describe the test plan by steps. -->
pod start log

```
 logs -n cattle-logging-system harvester-default-event-tailer-0
I0617 09:45:27.810035       1 main.go:120] Starting harvester-eventrouter version 0ff94899
I0617 09:45:27.810170       1 interfaces.go:36] Sink is [stdout]
I0617 09:45:27.810218       1 main.go:180] Starting shared Informer(s)
I0617 09:45:27.810324       1 eventrouter.go:130] Starting EventRouter
I0617 09:45:27.810337       1 main.go:161] Starting prometheus metrics.
```

#### Additional documentation or context
