### PR TITLE
common: bump go 1.24

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -8,7 +8,7 @@ RUN zypper -n rm container-suseconnect && \
 
 ## install golangci
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.8; \
     fi
 
 # The docker version in dapper is too old to have buildx. Install it manually.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heptiolabs/eventrouter
 
-go 1.23.4
+go 1.24.5
 
 replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
 

--- a/sinks/httpsink.go
+++ b/sinks/httpsink.go
@@ -144,13 +144,13 @@ func (h *HTTPSink) drainEvents(events []EventData) {
 
 	req, err := http.NewRequest("POST", h.SinkURL, h.bodyBuf)
 	if err != nil {
-		glog.Warningf(err.Error())
+		glog.Warningf("%s", err.Error())
 		return
 	}
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		glog.Warningf(err.Error())
+		glog.Warningf("%s", err.Error())
 		return
 	}
 

--- a/sinks/httpsink_test.go
+++ b/sinks/httpsink_test.go
@@ -64,7 +64,7 @@ func TestUpdateEvents(t *testing.T) {
 	}
 	podRef, err := ref.GetReference(scheme.Scheme, testPod)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("%s", err.Error())
 	}
 
 	evt := makeFakeEvent(podRef, corev1.EventTypeWarning, "CreateInCluster", "Fake pod creation event")


### PR DESCRIPTION
    - also, bump golangci-lint v1.64.8
    - fix minor linter error


(cherry picked from commit 6e10ecc19452c132a6c63b87a06153a6b4d78bc3)

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Bump go 1.24

#### Solution:
Bump go 1.24

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
