### PR TITLE
fix: use pinned versions and checksum validation

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,17 +4,10 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install git curl docker gzip tar wget awk
+    zypper -n install git curl docker docker-buildx gzip tar wget awk
 
-## install golangci
-RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest; \
-    fi
-
-# The docker version in dapper is too old to have buildx. Install it manually.
-RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.17.1/buildx-v0.17.1.linux-${ARCH} -o buildx-v0.17.1.linux-${ARCH} && \
-    chmod +x buildx-v0.17.1.linux-${ARCH} && \
-    mv buildx-v0.17.1.linux-${ARCH} /usr/local/bin/buildx
+# Copy golangci-lint binary from a multi-arch digest, zero-trust
+COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /go/src/github.com/heptiolabs/eventrouter/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
 TARGETS := $(shell ls scripts)
 
+SHA512SUM_Linux_aarch64  := 781951b31e5ff018a04e755c6da7163b31a81edda61f1bed4def8d0e4229865c58a3d26aa0cc4184058d91ebcae300ead2cad16d3c46ccb1098419e3e41a016
+SHA512SUM_Linux_x86_64   := d2ec27ecf9362e2fafd27d76d85a5c5b92b53aefe07cffa76bf9887db6bee07b1023cca8fc32a2c9bdd2ecfadaee71397066b41bd37c9ebbbbce09913f0884d4
+SHA512SUM_Darwin_arm64   := 8a356c89ad32af1698ae8615a6e303773a8ac58b114368454d59965ec2aa8282e780d1e228d37c301ce6f87596f68bfe7f204eb5f4c019c386a58dd94153ddcf
+SHA512SUM_Darwin_x86_64  := dbab05de04dda26793f4ae7875d0fba96ee54b0228e192fd40c0b2116ed345b5444047fc2e0c90cb481f28cbe0e0452bcecb268c8d074cd8615eb2f5463c30b6
+SHA512SUM_Windows_x86_64 := 807aee2f68b6da35cb0885558f5cbc9a6c8747a56c7a200f0e1fcac9e2fd0da570cbb39e48b3192bd1a71805f2ab38fd19d77faebba97a89e5d9a8b430ee429e
+
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/v0.6.0/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
+	@CHECKSUM=$$(shasum -a 512 .dapper.tmp | awk '{print $$1}'); \
+	if [ "$$CHECKSUM" != "$(SHA512SUM_$(shell uname -s)_$(shell uname -m))" ]; then \
+		echo "Checksum verification failed!"; \
+		exit 1; \
+	fi
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper

--- a/scripts/package
+++ b/scripts/package
@@ -11,5 +11,5 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-buildx build --load -f ${DOCKERFILE} -t ${IMAGE} .
+docker buildx build --load -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
Using pinned version for:
* golangci-lint to v2.11.3

Clear usage curl usage by:
* get docker-buildx through zypper
* checksum validation for dapper
* copy golangci-lint from container

#### Problem:
Explained in the body - not using generic versions and not validating binaries pulled through curl, or replacing curl with go install

#### Solution:
In description

#### Related Issue(s):
https://github.com/rancher/rancher-security/issues/1497

#### Test plan:
Green pipeline

#### Additional documentation or context
